### PR TITLE
fix(main): swap libc for (u)nix bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "alsa-sys",
  "bitflags 1.3.2",
  "libc",
- "nix",
+ "nix 0.23.2",
 ]
 
 [[package]]
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,7 +413,7 @@ dependencies = [
  "mach",
  "ndk 0.6.0",
  "ndk-glue",
- "nix",
+ "nix 0.23.2",
  "oboe 0.4.6",
  "parking_lot 0.11.2",
  "stdweb",
@@ -1165,6 +1171,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1937,10 +1955,10 @@ dependencies = [
  "cpal 0.15.3",
  "crossterm",
  "directories",
- "libc",
  "log",
  "magnum",
  "minreq",
+ "nix 0.31.2",
  "ratatui",
  "rodio 0.19.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ clap = { version = "4.5.58", features = ["derive"] }
 log = "0.4.29"
 simplelog = "0.12.2"
 magnum = { version = "1.0.1", features = ["rodio"] }
-minreq = { version = "2.11", default-features = false, features = ["https-native"] }
+minreq = { version = "2.11", default-features = false, features = [
+  "https-native",
+] }
 cpal = "0.15.3"
-libc = "0.2.182"
+# libc = "0.2.182"
+nix = { version = "0.31.2", default-features = false, features = ["fs"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,9 @@ use crossterm::{
 use log::LevelFilter;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use simplelog::{Config, WriteLogger};
-use std::fs::File;
 use std::io;
-use std::os::unix::io::AsRawFd;
 use std::time::Duration;
+use std::{fs::File, os::fd::AsFd};
 
 use std::panic;
 
@@ -37,11 +36,9 @@ fn main() -> Result<()> {
 
     if args.debug {
         let log_file = File::create("tanin.log")?;
-        let log_fd = log_file.as_raw_fd();
 
-        unsafe {
-            libc::dup2(log_fd, libc::STDERR_FILENO);
-        }
+        nix::unistd::dup2_stderr(log_file.as_fd())
+            .map_err(|e| anyhow::anyhow!("Failed to redirect stderr: {}", e))?;
 
         let log_file_clone = log_file.try_clone()?;
 
@@ -50,10 +47,8 @@ fn main() -> Result<()> {
     } else {
         // Redirect stderr to /dev/null to suppress errors in TUI
         if let Ok(dev_null) = File::open("/dev/null") {
-            let null_fd = dev_null.as_raw_fd();
-            unsafe {
-                libc::dup2(null_fd, libc::STDERR_FILENO);
-            }
+            nix::unistd::dup2_stderr(dev_null.as_fd())
+                .map_err(|e| anyhow::anyhow!("Failed to redirect stderr: {}", e))?;
         }
     }
 


### PR DESCRIPTION
# Summary

This change allows us to have the same behaviour but without the requirement for libc's unsafe API.
The dep. change has no effect on binary size.

## Reasoning
Unsafe code is not required here when we have safe bindings via the `nix` crate (of which is already compiled in anyway, hence no binary size difference).